### PR TITLE
Add variables to deal with hardcode problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Create an Azure SQL Database
 
 This Terraform module creates a basic Azure SQL Database.
 
-Usage
+Usage (Old Version)
 -----
 
 ```hcl
@@ -15,6 +15,27 @@ module "sql-database" {
   resource_group_name = "myapp"
   location            = "westus"
   db_name             = "mydatabase"
+  sql_admin_username  = "mradministrator"
+  sql_password        = "P@ssw0rd12345!"
+
+  tags             = {
+                        environment = "dev"
+                        costcenter  = "it"
+                      }
+  
+}
+```
+
+Usage (Current Version)
+-----
+
+```hcl
+module "sql-database" {
+  source              = "github.com/foreverXZC/terraform-azurerm-database"
+  resource_group_name = "myapp"
+  location            = "westus"
+  db_name             = "mydatabase"
+  server_name         = "server12345"
   sql_admin_username  = "mradministrator"
   sql_password        = "P@ssw0rd12345!"
 

--- a/main.tf
+++ b/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_sql_server" "server" {
 }
 
 resource "azurerm_sql_firewall_rule" "fw" {
-  name                = "acctfirewallrules"
+  name                = "${var.firewall_rule_name}"
   resource_group_name = "${azurerm_resource_group.rg.name}"
   server_name         = "${azurerm_sql_server.server.name}"
   start_ip_address    = "${var.start_ip_address}"

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,11 @@ variable "sql_password" {
   description = "The administrator password of the SQL Server."
 }
 
+variable "firewall_rule_name" {
+  description = "The name of the firewall rule to be created."
+  default = "acctfirewallrules"
+}
+
 variable "start_ip_address" {
   description = "Defines the start IP address used in your database firewall rule."
   default     = "0.0.0.0"


### PR DESCRIPTION
In previous version, server name and firewall name are hardcoded, which may incur name conflict. Now these names can be set by users. Server name is a required input and should be globally unique.
Furthermore, new usage is written in readme, where the only difference is server name and source, because the code for new version is only available in my GitHub repo. If my code is merged to original repo, I think the readme should be modified, including change the URL for source.
I will feel really glad if you could reply my pull request. If you have any questions, please contact me as soon as possible. Thanks a lot!