### PR TITLE
renaming module to sqldatbase to be consistent with the service name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
   - docker
 
 env:
-  - TERRAFORM_VERSION=0.11.7 IMAGE_NAME=azure-database-module
+  - TERRAFORM_VERSION=0.11.7 IMAGE_NAME=azure-sqldatabase-module
 
 jobs:
   include:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG BUILD_TERRAFORM_VERSION=0.11.7
 FROM microsoft/terraform-test:${BUILD_TERRAFORM_VERSION}
 
-ARG MODULE_NAME="terraform-azurerm-database"
+ARG MODULE_NAME="terraform-azurerm-sqldatabase"
 
 # Declare default build configurations for terraform.
 ARG BUILD_ARM_SUBSCRIPTION_ID=""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# terraform-azurerm-database
+# terraform-azurerm-sqldatabase
 
-[![Build Status](https://travis-ci.org/Azure/terraform-azurerm-database.svg?branch=master)](https://travis-ci.org/Azure/terraform-azurerm-database)
+[![Build Status](https://travis-ci.org/Azure/terraform-azurerm-sqldatabase.svg?branch=master)](https://travis-ci.org/Azure/terraform-azurerm-sqldatabase)
 
 ## Create an Azure SQL Database
 
@@ -72,7 +72,7 @@ We provide a Dockerfile to build a new image based `FROM` the `microsoft/terrafo
 #### Build the image
 
 ```sh
-$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-database-module .
+$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-sqldatabase-module .
 ```
 
 #### Run test (Docker)
@@ -80,19 +80,19 @@ $ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --buil
 This runs the build and unit tests:
 
 ```sh
-$ docker run --rm azure-database-module /bin/bash -c "bundle install && rake build"
+$ docker run --rm azure-sqldatabase-module /bin/bash -c "bundle install && rake build"
 ```
 
 This runs the end to end tests:
 
 ```sh
-$ docker run --rm azure-database-module /bin/bash -c "bundle install && rake e2e"
+$ docker run --rm azure-sqldatabase-module /bin/bash -c "bundle install && rake e2e"
 ```
 
 This runs the full tests:
 
 ```sh
-$ docker run --rm azure-database-module /bin/bash -c "bundle install && rake full"
+$ docker run --rm azure-sqldatabase-module /bin/bash -c "bundle install && rake full"
 ```
 
 ## Authors

--- a/test/terraform_database_test.go
+++ b/test/terraform_database_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/terraform"
 )
 
-func TestTerraformDatabase(t *testing.T) {
+func TestTerraformSqlDatabase(t *testing.T) {
 	t.Parallel()
 
 	terraformOptions := &terraform.Options{


### PR DESCRIPTION
changing the Terraform module name to be consistent with the name of the service.
i.e. sqldatabase rather than just database.

There are now multiple database services on Azure.
When searching on https://registry.terraform.io/ for SQL under Azure provider, you don't find a module for SQL Database as one might expect to do, you only find sql-server. 

